### PR TITLE
PB-680: Bruk konsistent versjon av react

### DIFF
--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -16,7 +16,7 @@ export default {
       maps: [
         {
           imports: {
-            react: "https://neik.dev.intern.nav.no/npm/@esm-bundle/react/v17/package/index.js",
+            react: "https://neik.dev.intern.nav.no/npm/@esm-bundle/react/17.0.1/package/index.js",
             "react-dom": "https://neik.dev.intern.nav.no/npm/@esm-bundle/react-dom/v17/package/index.js",
           },
         },


### PR DESCRIPTION
React feiler med en minified error når man bruker en inkonsistent versjon i react og react-dom. Denne PR-en fikser dette ved å bytte til en ikke aliased versjon av react som er konsistent med den som ligger i react-dom. 

PB-680: Bruk konsistent versjon av react